### PR TITLE
Provide pagination on file show views.

### DIFF
--- a/FilePaginatorPlugin.php
+++ b/FilePaginatorPlugin.php
@@ -14,6 +14,7 @@ class FilePaginatorPlugin extends Omeka_Plugin_AbstractPlugin
 {
     protected $_hooks = array(
         'public_head',
+        'public_footer',
         'config', 
         'config_form',
         );
@@ -24,12 +25,23 @@ class FilePaginatorPlugin extends Omeka_Plugin_AbstractPlugin
         'file_markup_options'
     );
 
+    public function hookInitialize()
+    {
+        get_view()->addHelperPath(dirname(__FILE__) . '/views/helpers', 'FilePaginator_View_Helper_FileShowPagination');
+    }
+
     public function hookPublicHead($args)
     {   
         queue_js_file('jquery.simplePagination');
         queue_js_file('filePagination');
         queue_css_file('simplePagination');
-        
+        queue_css_file('filePaginator');
+    }
+
+    public function hookPublicFooter($args)
+    {
+        $view = $args['view'];
+        echo $view->partial('common/file-show-pagination.php');
     }
 
     public function hookConfigForm($args) {
@@ -49,7 +61,7 @@ class FilePaginatorPlugin extends Omeka_Plugin_AbstractPlugin
         return '<div id="file-pagination" data-theme="' . $theme . '"></div>'.$html;
     }
 
-    public function filterFileMarkupOptions ($options) {
+    public function filterFileMarkupOptions($options) {
         if (get_option('file_paginator_links') == 1) {
             $options['linkAttributes']['target'] = '_blank';
         }

--- a/views/helpers/FileShowPagination.php
+++ b/views/helpers/FileShowPagination.php
@@ -13,17 +13,28 @@ class FilePaginator_View_Helper_FileShowPagination extends Zend_View_Helper_Abst
         if ($currentController == 'files') {
             $file = get_current_record('file');
             $originalItem = $file->getItem();
-            $originalItemFiles = $originalItem->getFiles();
+            $itemFiles = $originalItem->getFiles();
 
-            if (count($originalItemFiles) > 1) {
-                $html .= '<nav id="file-show-pagination" class="item-pagination"><ul class="navigation">';
+            if (count($itemFiles) > 1) {
+                $html .= '<nav id="file-show-pagination" class="item-pagination" aria-label="' . __('File navigation') . '"><ul class="navigation">';
                 $originalItemOrder = metadata($file, 'order');
-                if (array_key_exists($originalItemOrder - 2, $originalItemFiles)) {
-                    $previousFile = $originalItemFiles[$originalItemOrder - 2];
+                $currentFile = null;
+                $previousFile = null;
+                $nextFile = null;
+                foreach($itemFiles as $itemFile) {
+                    if ($itemFile->id === $file->id) {
+                        $currentFile = $itemFile;
+                    } elseif ($currentFile !== null) {
+                        $nextFile = $itemFile;
+                        break;
+                    } else {
+                        $previousFile = $itemFile;
+                    }
+                }
+                if ($previousFile) {
                     $html .= '<li class="previous">' . link_to($previousFile, 'show', __('Previous')) . '</li>';
                 }
-                if (array_key_exists($originalItemOrder, $originalItemFiles)) {
-                    $nextFile = $originalItemFiles[$originalItemOrder];
+                if ($nextFile) {
                     $html .= '<li class="next">' . link_to($nextFile, 'show', __('Next')) . '</li>';
                 }
                 $html .= '</ul></nav>';

--- a/views/helpers/FileShowPagination.php
+++ b/views/helpers/FileShowPagination.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * View helper for previous and next links on file show views.
+ * 
+ * @package FilePaginator\View\Helper
+ */
+class FilePaginator_View_Helper_FileShowPagination extends Zend_View_Helper_Abstract
+{
+    public function fileShowPagination()
+    {
+        $currentController = Zend_Controller_Front::getInstance()->getRequest()->getControllerName(); 
+        $html = '';
+        if ($currentController == 'files') {
+            $file = get_current_record('file');
+            $originalItem = $file->getItem();
+            $originalItemFiles = $originalItem->getFiles();
+
+            if (count($originalItemFiles) > 1) {
+                $html .= '<nav id="file-show-pagination" class="item-pagination"><ul class="navigation">';
+                $originalItemOrder = metadata($file, 'order');
+                if (array_key_exists($originalItemOrder - 2, $originalItemFiles)) {
+                    $previousFile = $originalItemFiles[$originalItemOrder - 2];
+                    $html .= '<li class="previous">' . link_to($previousFile, 'show', __('Previous')) . '</li>';
+                }
+                if (array_key_exists($originalItemOrder, $originalItemFiles)) {
+                    $nextFile = $originalItemFiles[$originalItemOrder];
+                    $html .= '<li class="next">' . link_to($nextFile, 'show', __('Next')) . '</li>';
+                }
+                $html .= '</ul></nav>';
+            }
+        }
+
+        return $html;
+    }
+}
+?>

--- a/views/shared/common/file-show-pagination.php
+++ b/views/shared/common/file-show-pagination.php
@@ -1,0 +1,1 @@
+<?php echo $this->fileShowPagination(); ?>

--- a/views/shared/css/filepaginator.css
+++ b/views/shared/css/filepaginator.css
@@ -1,0 +1,8 @@
+#file-show-pagination ul.navigation {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    list-style: none;
+    padding-left: 0;
+    margin-left: 0;
+}

--- a/views/shared/css/filepaginator.css
+++ b/views/shared/css/filepaginator.css
@@ -6,3 +6,7 @@
     padding-left: 0;
     margin-left: 0;
 }
+
+#file-show-pagination ul.navigation .next {
+    margin-left: auto;
+}

--- a/views/shared/javascripts/filePagination.js
+++ b/views/shared/javascripts/filePagination.js
@@ -1,35 +1,51 @@
 
 jQuery(function($) {
-    var pagination = $('#file-pagination')
-    if (!pagination.length) return;
-    var items = $(".single-file");
+    var paginateItemShowFiles = function() {
+        var pagination = $('#file-pagination')
+        if (!pagination.length) return;
+        var items = $(".single-file");
 
-    var numItems = items.length;
-    var perPage = 1;
-    var theme = pagination.data("theme");
+        var numItems = items.length;
+        var perPage = 1;
+        var theme = pagination.data("theme");
 
-    items.slice(perPage).hide();
+        items.slice(perPage).hide();
 
-    pagination.pagination({
-        items: numItems,
-        itemsOnPage: perPage,
-        cssStyle: theme,
+        pagination.pagination({
+            items: numItems,
+            itemsOnPage: perPage,
+            cssStyle: theme,
 
-        onPageClick: function(pageNumber) {
-            var showFrom = perPage * (pageNumber - 1);
-            var showTo = showFrom + perPage;
+            onPageClick: function(pageNumber) {
+                var showFrom = perPage * (pageNumber - 1);
+                var showTo = showFrom + perPage;
 
-            items.hide()
-            .slice(showFrom, showTo).show();
-        }
-    });
-    function checkFragment() {
-        var hash = window.location.hash || "#page-1";
-        hash = hash.match(/^#page-(\d+)$/);
-        if(hash) {
-            pagination.pagination("selectPage", parseInt(hash[1]));
-        }
-    };
-    $(window).bind("popstate", checkFragment);
-    checkFragment();
+                items.hide()
+                .slice(showFrom, showTo).show();
+            }
+        });
+        function checkFragment() {
+            var hash = window.location.hash || "#page-1";
+            hash = hash.match(/^#page-(\d+)$/);
+            if(hash) {
+                pagination.pagination("selectPage", parseInt(hash[1]));
+            }
+        };
+        $(window).bind("popstate", checkFragment);
+        checkFragment();
+    }
+
+    var moveFileShowPagination = function() {
+        var fileShowPagination = $('#file-show-pagination');
+        var content = $('#content');
+        fileShowPagination.appendTo(content);
+    }
+
+    if ($('body').hasClass('items show')) {
+        paginateItemShowFiles();
+    }
+
+    if ($('body').hasClass('files show')) {
+        moveFileShowPagination();
+    }
 });


### PR DESCRIPTION
This addresses kalbers/FilePaginator#2. It creates a `<nav>` element that mimics the markup for item pagination so that it can share existing styles. The view helper checks if the page is a file show view and attaches the markup to the footer. JS then moves it to the end of the container with `id="content"`. The markup placement is a little unfortunate, but we don't have any hooks on the file show.